### PR TITLE
docs: Add example usage of security_group_rules

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -116,6 +116,18 @@ module "opensearch" {
     }
   }
 
+  # Security Group rule example
+  security_group_rules = {
+    ingress_443 = {
+      type        = "ingress"
+      description = "HTTPS access from VPC"
+      from_port   = 443
+      to_port     = 443
+      ip_protocol = "tcp"
+      cidr_ipv4   = local.vpc_cidr
+    }
+  }
+
   # Access policy
   access_policy_statements = [
     {


### PR DESCRIPTION
## Description
Added example usage of security_group_rules to the documentation, because there was some lack of information