### PR TITLE
feat: Add `standby_replicas` to serverless collection and `auto_tune_options.use_off_peak_window` to domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,13 +144,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.24 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.40 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.24 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.40 |
 
 ## Modules
 

--- a/examples/collection/README.md
+++ b/examples/collection/README.md
@@ -20,13 +20,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.24 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.40 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.24 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.40 |
 
 ## Modules
 

--- a/examples/collection/main.tf
+++ b/examples/collection/main.tf
@@ -25,9 +25,10 @@ locals {
 module "opensearch_collection_public" {
   source = "../../modules/collection"
 
-  name        = "${local.name}-public"
-  description = "Example public OpenSearch Serverless collection"
-  type        = "SEARCH"
+  name             = "${local.name}-public"
+  description      = "Example public OpenSearch Serverless collection"
+  type             = "SEARCH"
+  standby_replicas = "DISABLED"
 
   create_access_policy  = true
   create_network_policy = true

--- a/examples/collection/versions.tf
+++ b/examples/collection/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.24"
+      version = ">= 5.40"
     }
   }
 }

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -1,6 +1,6 @@
 # Complete AWS OpenSearch Example
 
-Configuration in this directory creates an AWS OpenSEarch domain and resources
+Configuration in this directory creates an AWS OpenSearch domain and resources
 
 ## Usage
 
@@ -26,13 +26,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.24 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.40 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.24 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.40 |
 
 ## Modules
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.24"
+      version = ">= 5.40"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -79,6 +79,7 @@ resource "aws_opensearch_domain" "this" {
       }
 
       rollback_on_disable = try(auto_tune_options.value.rollback_on_disable, null)
+      use_off_peak_window = try(auto_tune_options.value.use_off_peak_window, null)
     }
   }
 

--- a/modules/collection/README.md
+++ b/modules/collection/README.md
@@ -42,13 +42,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.24 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.40 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.24 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.40 |
 
 ## Modules
 
@@ -92,6 +92,7 @@ No modules.
 | <a name="input_network_policy"></a> [network\_policy](#input\_network\_policy) | Network policy to apply to the collection | `any` | `{}` | no |
 | <a name="input_network_policy_description"></a> [network\_policy\_description](#input\_network\_policy\_description) | Description of the network policy | `string` | `null` | no |
 | <a name="input_network_policy_name"></a> [network\_policy\_name](#input\_network\_policy\_name) | Name of the network policy | `string` | `null` | no |
+| <a name="input_standby_replicas"></a> [standby\_replicas](#input\_standby\_replicas) | Indicates whether standby replicas should be used for a collection. One of ENABLED or DISABLED. Defaults to ENABLED. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Create and delete timeout configurations for the collection | `map(string)` | `{}` | no |
 | <a name="input_type"></a> [type](#input\_type) | Type of collection. One of `SEARCH`, `TIMESERIES`, or `VECTORSEARCH`. Defaults to `TIMESERIES` | `string` | `null` | no |

--- a/modules/collection/main.tf
+++ b/modules/collection/main.tf
@@ -13,9 +13,10 @@ locals {
 resource "aws_opensearchserverless_collection" "this" {
   count = var.create ? 1 : 0
 
-  description = var.description
-  name        = var.name
-  type        = var.type
+  description      = var.description
+  name             = var.name
+  type             = var.type
+  standby_replicas = var.standby_replicas
 
   tags = local.tags
 

--- a/modules/collection/variables.tf
+++ b/modules/collection/variables.tf
@@ -32,6 +32,12 @@ variable "type" {
   default     = null
 }
 
+variable "standby_replicas" {
+  description = "Indicates whether standby replicas should be used for a collection. One of ENABLED or DISABLED. Defaults to ENABLED."
+  type        = string
+  default     = null
+}
+
 variable "timeouts" {
   description = "Create and delete timeout configurations for the collection"
   type        = map(string)

--- a/modules/collection/versions.tf
+++ b/modules/collection/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.24"
+      version = ">= 5.40"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.24"
+      version = ">= 5.40"
     }
   }
 }

--- a/wrappers/collection/main.tf
+++ b/wrappers/collection/main.tf
@@ -26,6 +26,7 @@ module "wrapper" {
   network_policy                          = try(each.value.network_policy, var.defaults.network_policy, {})
   network_policy_description              = try(each.value.network_policy_description, var.defaults.network_policy_description, null)
   network_policy_name                     = try(each.value.network_policy_name, var.defaults.network_policy_name, null)
+  standby_replicas                        = try(each.value.standby_replicas, var.defaults.standby_replicas, null)
   tags                                    = try(each.value.tags, var.defaults.tags, {})
   timeouts                                = try(each.value.timeouts, var.defaults.timeouts, {})
   type                                    = try(each.value.type, var.defaults.type, null)


### PR DESCRIPTION
## Description
Support `standby_replicas` argument in serverless collection. 
Support `auto_tune_options.use_off_peak_window` in opensearch domain. 

## Motivation and Context
https://github.com/hashicorp/terraform-provider-aws/issues/34675
https://github.com/hashicorp/terraform-provider-aws/pull/36067

## Breaking Changes
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
