### PR TITLE
fix: Do not create default zone_awareness_config if it not set

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -106,7 +106,7 @@ resource "aws_opensearch_domain" "this" {
       warm_type                     = try(cluster_config.value.warm_type, null)
 
       dynamic "zone_awareness_config" {
-        for_each = try([cluster_config.value.zone_awareness_config], [{}])
+        for_each = try([cluster_config.value.zone_awareness_config], [])
 
         content {
           availability_zone_count = try(zone_awareness_config.value.availability_zone_count, null)


### PR DESCRIPTION
## Description

### Current behavior

If I don't define the `cluster_config.zone_awareness_config` (or define it as an empty map, e.g `zone_awareness_config={}`), the module creates the following `zone_awareness_config` anyway:

```
      ~ cluster_config {
            # (8 unchanged attributes hidden)

          + zone_awareness_config {
              + availability_zone_count = 2
            }

            # (1 unchanged block hidden)
        }
```

### Expected behavior

That block should be omitted if I don't define the `cluster_config.zone_awareness_config`.

### Why it's happening

The current code creates the `zone_awareness_config` block even if `cluster_config.value.zone_awareness_config` is empty or omitted. This behavior was reflected (but not so quietly) in provider documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain#zone_awareness_config

> [availability_zone_count](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain#availability_zone_count) - (Optional) Number of Availability Zones for the domain to use with zone_awareness_enabled. Defaults to 2. Valid values: 2 or 3.

So, if we pass an empty map for the `zone_awareness_config` in the `aws_elasticsearch_domain`, the provider sets `availability_zone_count = 2` by default. 

In my opinion, this is unclear behavior of the provider, but we can mitigate it in the module if we'll pass a `null` instead of an empty map in case of an undefined `cluster_config.value.zone_awareness_config`.

## Motivation and Context

In the case of disabled zone awareness (`zone_awareness_enabled = false`) undefined  `cluster_config.value.zone_awareness_config` causes non-idempotent runs of Terraform, because the module tries to create a `zone_awareness_config` block each run and didn't succeed, because zone awareness is disabled. That PR will fix it.

## Breaking Changes

No, this is a minor change.