### PR TITLE
fix(master_user_options): User and Pass can be set

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,9 +45,9 @@ resource "aws_opensearch_domain" "this" {
         for_each = try([advanced_security_options.value.master_user_options], [{}])
 
         content {
-          master_user_arn      = try(master_user_options.value.master_user_arn, null) == null ? try(master_user_options.value.master_user_arn, data.aws_iam_session_context.current[0].issuer_arn) : null
-          master_user_name     = try(master_user_options.value.master_user_name, null) == null ? try(master_user_options.value.master_user_name, null) : null
-          master_user_password = try(master_user_options.value.master_user_password, null) == null ? try(master_user_options.value.master_user_password, null) : null
+          master_user_arn      = try(advanced_security_options.value.internal_user_database_enabled, false) ? null : (try(master_user_options.value.master_user_arn, null) == null ? data.aws_iam_session_context.current[0].issuer_arn : try(master_user_options.value.master_user_arn, null))
+          master_user_name     = try(advanced_security_options.value.internal_user_database_enabled, false) ? try(master_user_options.value.master_user_name, null) : null
+          master_user_password = try(advanced_security_options.value.internal_user_database_enabled, false) ? try(master_user_options.value.master_user_password, null) : null
         }
       }
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR fixes conditionals around master_user_options to make sure the proper one is set

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The module is not properly setting internal database attributes (user and password or arn).
There is a bug in the logic that governs the conditionals.
Based the resource's documentation:
<img width="702" alt="Screenshot 2024-04-09 at 12 58 57" src="https://github.com/terraform-aws-modules/terraform-aws-opensearch/assets/2984201/3f410181-05fa-45ea-a510-b023e2f7939b">

The first condition that should be checked is `internal_user_database_enabled` and decide whether ARN or User and Pass will be used. 
What is happening now is that `user and pass` are ignored and `ARN` is always set even if `internal_user_database_enabled` is explicitly set to `false`

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
Not breaking changes expected

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
