### PR TITLE
fix: Fix the condition of the logical operators of `master_user_arn`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,7 @@ resource "aws_opensearch_domain" "this" {
         for_each = try([advanced_security_options.value.master_user_options], [{}])
 
         content {
-          master_user_arn      = try(master_user_options.value.master_user_arn, null) == null ? try(master_user_options.value.master_user_arn, data.aws_iam_session_context.current[0].issuer_arn) : null
+          master_user_arn      = try(master_user_options.value.master_user_name, null) == null && try(master_user_options.value.master_user_password, null) == null ? try(master_user_options.value.master_user_arn, data.aws_iam_session_context.current[0].issuer_arn) : null
           master_user_name     = try(master_user_options.value.master_user_arn, null) == null ? try(master_user_options.value.master_user_name, null) : null
           master_user_password = try(master_user_options.value.master_user_arn, null) == null ? try(master_user_options.value.master_user_password, null) : null
         }


### PR DESCRIPTION
## Description
Specifying the master_user_arn will result in it being interpreted as null, causing property value not to be applied.
An error exists in the logical operator for that property value.

## Motivation and Context
Due to that change, we can properly use master_user_arn

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
