### PR TITLE
fix: Create a domain policy that implicitly depends_on domain

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -264,7 +264,7 @@ locals {
 resource "aws_opensearch_domain_policy" "this" {
   count = var.create && var.enable_access_policy && (local.create_access_policy || var.access_policies != null) ? 1 : 0
 
-  domain_name     = var.domain_name
+  domain_name     = aws_opensearch_domain.this[0].domain_name
   access_policies = local.create_access_policy ? data.aws_iam_policy_document.this[0].json : var.access_policies
 }
 


### PR DESCRIPTION
## Description
Create a domain policy that implicitly depends_on domain

## Motivation and Context
When creating a domain policy through the var.access_policies variable, terraform execution fails and prompts that the specified domain cannot be found,
The above problem can be solved by establishing an implicit depends_on between domain policy and domain

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
no
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
I have passed the test
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
