### PR TITLE
docs(vpc_options): Improve description for public access

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ No modules.
 | <a name="input_software_update_options"></a> [software\_update\_options](#input\_software\_update\_options) | Software update options for the domain | `any` | <pre>{<br>  "auto_software_update_enabled": true<br>}</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_vpc_endpoints"></a> [vpc\_endpoints](#input\_vpc\_endpoints) | Map of VPC endpoints to create for the domain | `any` | `{}` | no |
-| <a name="input_vpc_options"></a> [vpc\_options](#input\_vpc\_options) | Configuration block for VPC related options. Adding or removing this configuration forces a new resource ([documentation](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-vpc.html#es-vpc-limitations)) | `any` | `{}` | no |
+| <a name="input_vpc_options"></a> [vpc\_options](#input\_vpc\_options) | Configuration block for VPC related options. Adding or removing this configuration forces a new resource ([documentation](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-vpc.html#es-vpc-limitations)). Leave empty to deploy with public access | `any` | `{}` | no |
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -134,7 +134,7 @@ variable "software_update_options" {
 }
 
 variable "vpc_options" {
-  description = "Configuration block for VPC related options. Adding or removing this configuration forces a new resource ([documentation](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-vpc.html#es-vpc-limitations))"
+  description = "Configuration block for VPC related options. Adding or removing this configuration forces a new resource ([documentation](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-vpc.html#es-vpc-limitations)). Leave empty to deploy with public access"
   type        = any
   default     = {}
 }


### PR DESCRIPTION
## Description
It took me a while to realise that I had to leave the `vpc_options variable = {}` to deploy a public opensearch. I propose to provide a little more explanation

## Motivation and Context
Making the creation of a public opensearch more explicit

## Breaking Changes
None

## How Has This Been Tested?
I ran pre-commit
