### PR TITLE
fix: Correct evaluation logic when determining `master_user_options` arguments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,7 @@ resource "aws_opensearch_domain" "this" {
         for_each = try([advanced_security_options.value.master_user_options], [{}])
 
         content {
-          master_user_arn      = try(master_user_options.value.master_user_arn, null) == null ? try(master_user_options.value.master_user_arn, data.aws_iam_session_context.current[0].issuer_arn) : null
+          master_user_arn      = try(master_user_options.value.master_user_arn, null) != null ? try(master_user_options.value.master_user_arn, data.aws_iam_session_context.current[0].issuer_arn) : null
           master_user_name     = try(master_user_options.value.master_user_arn, null) == null ? try(master_user_options.value.master_user_name, null) : null
           master_user_password = try(master_user_options.value.master_user_arn, null) == null ? try(master_user_options.value.master_user_password, null) : null
         }


### PR DESCRIPTION
## Description
https://github.com/terraform-aws-modules/terraform-aws-opensearch/issues/18

## How Has This Been Tested?

1. 
```
advanced_security_options = {
    enabled                        = true
    anonymous_auth_enabled         = false
    internal_user_database_enabled = true

    master_user_options = {
      master_user_name     = "admin"
      master_user_password = "PasswoRd12-"
    }
  }
```

2.

```
advanced_security_options = {
    enabled                        = true
    anonymous_auth_enabled         = false
    internal_user_database_enabled = false

    master_user_options = {
      master_user_arn     = aws_iam_user.opensearch_cluster.arn
    }
  }
```

- Resolves #18
- Resolves #19