### PR TITLE
feat: Add timeout for opensearch domain

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.2
+    rev: v1.92.0
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each
@@ -22,10 +22,9 @@ repos:
           - '--args=--only=terraform_required_providers'
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
-          - '--args=--only=terraform_unused_required_providers'
       - id: terraform_validate
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ No modules.
 | <a name="input_security_group_use_name_prefix"></a> [security\_group\_use\_name\_prefix](#input\_security\_group\_use\_name\_prefix) | Determines whether the security group name (`security_group_name`) is used as a prefix | `bool` | `true` | no |
 | <a name="input_software_update_options"></a> [software\_update\_options](#input\_software\_update\_options) | Software update options for the domain | `any` | <pre>{<br>  "auto_software_update_enabled": true<br>}</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Create and delete timeout configurations for the domain | `map(string)` | `{}` | no |
 | <a name="input_vpc_endpoints"></a> [vpc\_endpoints](#input\_vpc\_endpoints) | Map of VPC endpoints to create for the domain | `any` | `{}` | no |
 | <a name="input_vpc_options"></a> [vpc\_options](#input\_vpc\_options) | Configuration block for VPC related options. Adding or removing this configuration forces a new resource ([documentation](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-vpc.html#es-vpc-limitations)) | `any` | `{}` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -224,6 +224,11 @@ resource "aws_opensearch_domain" "this" {
     }
   }
 
+  timeouts {
+    create = try(var.timeouts.create, null)
+    delete = try(var.timeouts.delete, null)
+  }
+
   tags = local.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -139,6 +139,12 @@ variable "vpc_options" {
   default     = {}
 }
 
+variable "timeouts" {
+  description = "Create and delete timeout configurations for the domain"
+  type        = map(string)
+  default     = {}
+}
+
 ################################################################################
 # Package Association(s)
 ################################################################################

--- a/wrappers/collection/versions.tf
+++ b/wrappers/collection/versions.tf
@@ -1,3 +1,10 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.54"
+    }
+  }
 }

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -72,6 +72,7 @@ module "wrapper" {
     auto_software_update_enabled = true
   })
   tags          = try(each.value.tags, var.defaults.tags, {})
+  timeouts      = try(each.value.timeouts, var.defaults.timeouts, {})
   vpc_endpoints = try(each.value.vpc_endpoints, var.defaults.vpc_endpoints, {})
   vpc_options   = try(each.value.vpc_options, var.defaults.vpc_options, {})
 }

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -1,3 +1,10 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.54"
+    }
+  }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
I just had several problems because as of today creating an opensearch domain takes more than an hour, a few days ago this was not a problem, surely something changed internally in the AWS API.
![image](https://github.com/terraform-aws-modules/terraform-aws-opensearch/assets/8176821/c83b8dd1-f433-40ee-a4c3-6b4b4429e181)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The module throws a tiemeout error when trying to create the resource, if you try to run `terraform apply` again, Terraform will recreate the resource (wait another hour).

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
Nop

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
