### PR TITLE
feat: Added dual-stack domain endpoints to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,13 +144,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.54 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.64 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.54 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.64 |
 
 ## Modules
 
@@ -234,7 +234,9 @@ No modules.
 | <a name="output_cloudwatch_logs"></a> [cloudwatch\_logs](#output\_cloudwatch\_logs) | Map of CloudWatch log groups created and their attributes |
 | <a name="output_domain_arn"></a> [domain\_arn](#output\_domain\_arn) | The Amazon Resource Name (ARN) of the domain |
 | <a name="output_domain_dashboard_endpoint"></a> [domain\_dashboard\_endpoint](#output\_domain\_dashboard\_endpoint) | Domain-specific endpoint for Dashboard without https scheme |
+| <a name="output_domain_dashboard_endpoint_v2"></a> [domain\_dashboard\_endpoint\_v2](#output\_domain\_dashboard\_endpoint\_v2) | V2 domain endpoint for Dashboard that works with both IPv4 and IPv6 addresses, without https scheme |
 | <a name="output_domain_endpoint"></a> [domain\_endpoint](#output\_domain\_endpoint) | Domain-specific endpoint used to submit index, search, and data upload requests |
+| <a name="output_domain_endpoint_v2"></a> [domain\_endpoint\_v2](#output\_domain\_endpoint\_v2) | V2 domain endpoint that works with both IPv4 and IPv6 addresses, used to submit index, search, and data upload requests |
 | <a name="output_domain_id"></a> [domain\_id](#output\_domain\_id) | The unique identifier for the domain |
 | <a name="output_outbound_connections"></a> [outbound\_connections](#output\_outbound\_connections) | Map of outbound connections created and their attributes |
 | <a name="output_package_associations"></a> [package\_associations](#output\_package\_associations) | Map of package associations created and their attributes |

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,9 +17,19 @@ output "domain_endpoint" {
   value       = try(aws_opensearch_domain.this[0].endpoint, null)
 }
 
+output "domain_endpoint_v2" {
+  description = "V2 domain endpoint that works with both IPv4 and IPv6 addresses, used to submit index, search, and data upload requests"
+  value       = try(aws_opensearch_domain.this[0].endpoint_v2, null)
+}
+
 output "domain_dashboard_endpoint" {
   description = "Domain-specific endpoint for Dashboard without https scheme"
   value       = try(aws_opensearch_domain.this[0].dashboard_endpoint, null)
+}
+
+output "domain_dashboard_endpoint_v2" {
+  description = "V2 domain endpoint for Dashboard that works with both IPv4 and IPv6 addresses, without https scheme"
+  value       = try(aws_opensearch_domain.this[0].dashboard_endpoint_v2, null)
 }
 
 ################################################################################

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.54"
+      version = ">= 5.64"
     }
   }
 }

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.54"
+      version = ">= 5.64"
     }
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Added [new](https://github.com/hashicorp/terraform-provider-aws/issues/38012) dual-stack domain and dashboards endpoints to the outputs of this module.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Use dual-stack OpenSearch domains.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

no

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
