### PR TITLE
fix: Add the ability to configure policy for cross cluster OpenSearch

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -288,7 +288,10 @@ data "aws_iam_policy_document" "this" {
       not_actions = try(statement.value.not_actions, null)
       effect      = try(statement.value.effect, null)
       resources = try(statement.value.resources,
-        [for path in try(statement.value.resource_paths, ["*"]) : "${aws_opensearch_domain.this[0].arn}/${path}"]
+        [
+          for path in try(statement.value.resource_paths, ["*"]) : 
+          "${aws_opensearch_domain.this[0].arn}${path == "/*" ? "/*" : path}"
+          ]
       )
       not_resources = try(statement.value.not_resources, null)
 


### PR DESCRIPTION
## Description
This change modifies the default behavior of the policy creation for cross-cluster access in AWS OpenSearch. Specifically, it enables the creation of policies with the "es:ESCrossClusterGet" action without the `/*` suffix at the end of the ARN, as required by AWS for certain cross-cluster access configurations.

## Motivation and Context
The modification aligns with the AWS documentation for cross-cluster replication ([link to AWS article](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/replication.html)), which specifies that the `Action` field for cross-cluster requests must omit the `/*` suffix. By default, this change ensures the correct format for the policy without impacting other configurations.

## Breaking Changes
No, this change does not break backward compatibility with the current major version.

## How Has This Been Tested?
- [x] I have tested and validated these changes locally by creating the OpenSearch configuration with the modified policy in my module.
- [ ] I have not updated the `examples/*` directory, as there are no existing examples for cross-cluster configurations.
- [x] I have executed `pre-commit run -a` on my pull request with the following results:
  - **Terraform fmt**: Passed
  - **Terraform wrapper with for_each in module**: Passed
  - **Terraform docs**: Passed
  - **Terraform validate with tflint**: Passed
  - **Terraform validate**: Passed
  - **Check for merge conflicts**: Passed
  - **Fix end of files**: Passed
  - **Trim trailing whitespace**: Passed

