### PR TITLE
fix: Skip `zone_awareness_config` if `zone_awareness` is not enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -106,7 +106,7 @@ resource "aws_opensearch_domain" "this" {
       warm_type                     = try(cluster_config.value.warm_type, null)
 
       dynamic "zone_awareness_config" {
-        for_each = cluster_config.value.zone_awareness_enabled ? try([cluster_config.value.zone_awareness_config], []) : []
+        for_each = try(cluster_config.value.zone_awareness_enabled, true) ? try([cluster_config.value.zone_awareness_config], []) : []
 
         content {
           availability_zone_count = try(zone_awareness_config.value.availability_zone_count, null)

--- a/main.tf
+++ b/main.tf
@@ -106,7 +106,7 @@ resource "aws_opensearch_domain" "this" {
       warm_type                     = try(cluster_config.value.warm_type, null)
 
       dynamic "zone_awareness_config" {
-        for_each = try([cluster_config.value.zone_awareness_config], [])
+        for_each = cluster_config.value.zone_awareness_enabled ? try([cluster_config.value.zone_awareness_config], []) : []
 
         content {
           availability_zone_count = try(zone_awareness_config.value.availability_zone_count, null)


### PR DESCRIPTION
## Description

`zone_awareness_config` should be considered only if zone_awareness is enabled.

## Motivation and Context

When `zone_awareness_enabled` is `false` and `zone_awareness_config` is set (whatever the value, even `null` or `{}`), the module keeps trying to modify aws opensearch cluster and apply this `zone_awareness_config`. Obvisouly AWS doesn't consider it since awareness_config is only relevant when awareness is enabled. So this provokes a continuous terraform drift. 
Note that we can't just remove the zone_awareness_config from our TF code since we actually uses it for some environements.

## How Has This Been Tested?
- I modified the module locally and there is no more a terraform drift. Module won't apply any zone_awareness_config if `zone_awareness_enabled` is `false`