### PR TITLE
fix typo in examples and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ module "opensearch" {
 
       actions = ["es:*"]
 
-      condition = [{
+      conditions = [{
         test     = "IpAddress"
         variable = "aws:SourceIp"
         values   = ["127.0.0.1/32"]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -142,7 +142,7 @@ module "opensearch" {
 
       actions = ["es:*"]
 
-      condition = [{
+      conditions = [{
         test     = "IpAddress"
         variable = "aws:SourceIp"
         values   = ["127.0.0.1/32"]


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixed a typo in the example in the `README.md` and the `examples/complete/main.tf` files where the `access_policy_statements` `conditions` was written as `condition`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I was deploying an opensearch domain and didn't see any of my conditions appear in terraform plans. so I reviewed the code and found that the dynamic block `condition` was looking for `statement.value.conditions`

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
