### PR TITLE
fix: Add region for subnets recovery

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,7 @@
 data "aws_region" "current" {
   count = var.create ? 1 : 0
+
+  region = var.region
 }
 data "aws_partition" "current" {
   count = var.create ? 1 : 0
@@ -494,7 +496,8 @@ locals {
 data "aws_subnet" "this" {
   count = local.create_security_group ? 1 : 0
 
-  id = element(var.vpc_options.subnet_ids, 0)
+  region = var.region
+  id     = element(var.vpc_options.subnet_ids, 0)
 }
 
 resource "aws_security_group" "this" {


### PR DESCRIPTION
## Description
When retrieving subnets via the aws_subnet datasource, we must specify the region to get the subnets in the target region.

## Motivation and Context
Data such as subnets are regionalized. We must ensure that we retrieve the subnets in the region configured in the region variable; otherwise, the provider's region is used, which is incorrect.

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have executed `pre-commit run -a` on my pull request

