### PR TITLE
Add option for GPU acceleration

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,13 +144,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.31 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.28 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.31 |
 
 ## Modules
 
@@ -189,7 +189,7 @@ No modules.
 | <a name="input_access_policy_statements"></a> [access\_policy\_statements](#input\_access\_policy\_statements) | A map of IAM policy [statements](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#statement) for custom permission usage | `any` | `{}` | no |
 | <a name="input_advanced_options"></a> [advanced\_options](#input\_advanced\_options) | Key-value string pairs to specify advanced configuration options. Note that the values for these configuration options must be strings (wrapped in quotes) or they may be wrong and cause a perpetual diff, causing Terraform to want to recreate your Elasticsearch domain on every apply | `map(string)` | `{}` | no |
 | <a name="input_advanced_security_options"></a> [advanced\_security\_options](#input\_advanced\_security\_options) | Configuration block for [fine-grained access control](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/fgac.html) | `any` | <pre>{<br/>  "anonymous_auth_enabled": false,<br/>  "enabled": true<br/>}</pre> | no |
-| <a name="input_aiml_options"></a> [aiml\_options](#input\_aiml\_options) | Configuration block for Natural Language Query Generation and s3 Vectors | <pre>object({<br/>    natural_language_query_generation_options = optional(object({<br/>      desired_state = optional(string)<br/>    }))<br/>    s3_vectors_engine = optional(object({<br/>      enabled = optional(bool)<br/>    }))<br/>  })</pre> | `null` | no |
+| <a name="input_aiml_options"></a> [aiml\_options](#input\_aiml\_options) | Configuration block for AI/ML options including Natural Language Query Generation, S3 Vectors, and Serverless Vector Acceleration | <pre>object({<br/>    natural_language_query_generation_options = optional(object({<br/>      desired_state = optional(string)<br/>    }))<br/>    s3_vectors_engine = optional(object({<br/>      enabled = optional(bool)<br/>    }))<br/>    serverless_vector_acceleration = optional(object({<br/>      enabled = optional(bool)<br/>    }))<br/>  })</pre> | `null` | no |
 | <a name="input_auto_tune_options"></a> [auto\_tune\_options](#input\_auto\_tune\_options) | Configuration block for the Auto-Tune options of the domain | `any` | <pre>{<br/>  "desired_state": "ENABLED",<br/>  "rollback_on_disable": "NO_ROLLBACK"<br/>}</pre> | no |
 | <a name="input_cloudwatch_log_group_class"></a> [cloudwatch\_log\_group\_class](#input\_cloudwatch\_log\_group\_class) | Specified the log class of the log group. Possible values are: STANDARD or INFREQUENT\_ACCESS | `string` | `null` | no |
 | <a name="input_cloudwatch_log_group_kms_key_id"></a> [cloudwatch\_log\_group\_kms\_key\_id](#input\_cloudwatch\_log\_group\_kms\_key\_id) | If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html) | `string` | `null` | no |

--- a/examples/collection/README.md
+++ b/examples/collection/README.md
@@ -20,13 +20,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.31 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.28 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.31 |
 
 ## Modules
 

--- a/examples/collection/versions.tf
+++ b/examples/collection/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.31"
     }
   }
 }

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -26,13 +26,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.31 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.28 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.31 |
 
 ## Modules
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.31"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -72,6 +72,14 @@ resource "aws_opensearch_domain" "this" {
           enabled = s3_vectors_engine.value.enabled
         }
       }
+
+      dynamic "serverless_vector_acceleration" {
+        for_each = aiml_options.value.serverless_vector_acceleration != null ? [aiml_options.value.serverless_vector_acceleration] : []
+
+        content {
+          enabled = serverless_vector_acceleration.value.enabled
+        }
+      }
     }
   }
 

--- a/modules/collection/README.md
+++ b/modules/collection/README.md
@@ -42,13 +42,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.31 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.28 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.31 |
 
 ## Modules
 

--- a/modules/collection/versions.tf
+++ b/modules/collection/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.31"
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -30,12 +30,15 @@ variable "advanced_security_options" {
 }
 
 variable "aiml_options" {
-  description = "Configuration block for Natural Language Query Generation and s3 Vectors"
+  description = "Configuration block for AI/ML options including Natural Language Query Generation, S3 Vectors, and Serverless Vector Acceleration"
   type = object({
     natural_language_query_generation_options = optional(object({
       desired_state = optional(string)
     }))
     s3_vectors_engine = optional(object({
+      enabled = optional(bool)
+    }))
+    serverless_vector_acceleration = optional(object({
       enabled = optional(bool)
     }))
   })

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.31"
     }
   }
 

--- a/wrappers/collection/versions.tf
+++ b/wrappers/collection/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.31"
     }
   }
 

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.31"
     }
   }
 


### PR DESCRIPTION
## Description
Add option for GPU acceleration

## Motivation and Context
The GPU acceleration feature is available for AWS Managed OpenSearch and we'd like to be able to use it with this provider.

### Related issues
- https://github.com/hashicorp/terraform-provider-aws/issues/45657                                                   
- https://github.com/hashicorp/terraform-provider-aws/pull/45882
   - Blocking tests from passing

## Breaking Changes
No

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have executed `pre-commit run -a` on my pull request